### PR TITLE
feat: atomWithStoreHistory

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-prettier": "^5.2.3",
     "happy-dom": "^15.11.7",
     "jiti": "^2.4.2",
-    "jotai": "2.11.1",
+    "jotai": "2.12.1",
     "jotai-history": "link:",
     "prettier": "^3.4.2",
     "react": "^19.0.0",
@@ -91,7 +91,7 @@
     "vitest": "^3.0.3"
   },
   "peerDependencies": {
-    "jotai": ">=2.9.0"
+    "jotai": ">=2.12.1"
   },
   "engines": {
     "node": ">=12.20.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ devDependencies:
     specifier: ^2.4.2
     version: 2.4.2
   jotai:
-    specifier: 2.11.1
-    version: 2.11.1(@types/react@19.0.10)(react@19.0.0)
+    specifier: 2.12.1
+    version: 2.12.1(@types/react@19.0.10)(react@19.0.0)
   jotai-history:
     specifier: 'link:'
     version: 'link:'
@@ -2379,8 +2379,8 @@ packages:
     hasBin: true
     dev: true
 
-  /jotai@2.11.1(@types/react@19.0.10)(react@19.0.0):
-    resolution: {integrity: sha512-41Su098mpHIX29hF/XOpDb0SqF6EES7+HXfrhuBqVSzRkxX48hD5i8nGsEewWZNAsBWJCTTmuz8M946Ih2PfcQ==}
+  /jotai@2.12.1(@types/react@19.0.10)(react@19.0.0):
+    resolution: {integrity: sha512-VUW0nMPYIru5g89tdxwr9ftiVdc/nGV9jvHISN8Ucx+m1vI9dBeHemfqYzEuw5XSkmYjD/MEyApN9k6yrATsZQ==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'

--- a/src/storeHistory.ts
+++ b/src/storeHistory.ts
@@ -1,0 +1,82 @@
+import { type Atom, atom } from 'jotai/vanilla'
+import {
+  INTERNAL_getBuildingBlocksRev1 as getBuildingBlocks,
+  INTERNAL_initializeStoreHooks as initializeStoreHooks,
+} from 'jotai/vanilla/internals'
+import { RESET } from './actions'
+
+export function atomWithStoreHistory(limit: number) {
+  const refreshAtom = atom(0)
+  refreshAtom.debugPrivate = true
+  const historyAtom = atom(new Map<Atom<unknown>, unknown[]>())
+  historyAtom.debugPrivate = true
+  const refreshableHistoryAtom = atom(
+    (get) => (get(refreshAtom), get(historyAtom)),
+    (get, set, action: RESET) => {
+      if (action === RESET) {
+        get(historyAtom).clear()
+        set(refreshAtom, (v) => v + 1)
+      }
+    }
+  )
+  refreshableHistoryAtom.debugPrivate = true
+  refreshableHistoryAtom.unstable_onInit = (store) => {
+    const buildingBlocks = getBuildingBlocks(store)
+    const mountedMap = buildingBlocks[1]
+    const storeHooks = initializeStoreHooks(buildingBlocks[6])
+    const atomHistory = store.get(historyAtom)!
+    let hasChanged = false
+    const subscribeAll = (): (() => void) =>
+      collectFns(
+        storeHooks.c.add(undefined, function onChange(atom) {
+          if (atom.debugPrivate) {
+            return
+          }
+          if (mountedMap.has(atom) && !atomHistory.has(atom)) {
+            atomHistory.set(atom, [])
+          }
+          const history = atomHistory.get(atom)
+          if (!history) {
+            return
+          }
+          hasChanged = true
+          atomHistory.set(atom, [store.get(atom), ...history].slice(0, limit))
+        }),
+        storeHooks.m.add(undefined, function onMount(atom) {
+          if (atom.debugPrivate) {
+            return
+          }
+          atomHistory.set(atom, [store.get(atom)])
+        }),
+        storeHooks.u.add(undefined, function onUnmount(atom) {
+          if (atom.debugPrivate) {
+            return
+          }
+          atomHistory.delete(atom)
+        }),
+        storeHooks.f.add(function onFlush() {
+          // refresh the history atom on flush
+          if (hasChanged) {
+            hasChanged = false
+            store.set(refreshAtom, (v) => v + 1)
+          }
+        })
+      )
+    let unsubscribeAll: () => void
+    storeHooks.m.add(refreshableHistoryAtom, function unsubOnMount() {
+      unsubscribeAll = subscribeAll()
+    })
+    storeHooks.u.add(refreshableHistoryAtom, function unsubOnMount() {
+      unsubscribeAll()
+    })
+  }
+  return refreshableHistoryAtom
+}
+
+function collectFns(...fns: (() => void)[]) {
+  return () => fns.forEach(callFn)
+}
+
+function callFn(fn: () => void) {
+  return fn()
+}

--- a/src/withUndoableHistory.ts
+++ b/src/withUndoableHistory.ts
@@ -23,12 +23,14 @@ export function withUndoableHistory<T extends Atom<unknown>>(
   targetAtom: T,
   limit: number
 ): WithUndoableHistory<T> {
-  const historyAtom = withPrivate(withHistory(targetAtom, limit))
+  const historyAtom = withHistory(targetAtom, limit)
+  historyAtom.debugPrivate = true
   let undoAtom: ReturnType<typeof withUndo> | undefined
   if (isWritableAtom(targetAtom)) {
     // eslint-disable-next-line prefer-rest-params
     const getArgs = arguments[2] ?? Array.of
-    undoAtom = withPrivate(withUndo(historyAtom, targetAtom, limit, getArgs))
+    undoAtom = withUndo(historyAtom, targetAtom, limit, getArgs)
+    undoAtom.debugPrivate = true
   }
   return atom(
     (get) =>
@@ -63,9 +65,4 @@ function isWritableAtom<T extends Atom<unknown>>(
   atom: T
 ): atom is T & InferWritableAtom<T> {
   return 'write' in atom
-}
-
-function withPrivate<T extends Atom<unknown>>(atom: T) {
-  atom.debugPrivate = true
-  return atom
 }

--- a/tests/storeHistory.test.ts
+++ b/tests/storeHistory.test.ts
@@ -1,0 +1,125 @@
+import { atom, createStore } from 'jotai/vanilla'
+import type { PrimitiveAtom } from 'jotai/vanilla'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { RESET } from '../src/actions'
+import { atomWithStoreHistory } from '../src/storeHistory'
+
+describe('storeHistory', () => {
+  let store: ReturnType<typeof createStore>
+  let historyAtom: ReturnType<typeof atomWithStoreHistory>
+  let atom1: PrimitiveAtom<number>
+  let atom2: PrimitiveAtom<string>
+  let privateAtom: PrimitiveAtom<boolean>
+  let unsubHistory: () => void
+  let unsubAtom1: () => void
+
+  beforeEach(() => {
+    store = createStore()
+    historyAtom = atomWithStoreHistory(3) // Limit history to 3 entries
+    unsubHistory = store.sub(historyAtom, () => {})
+
+    atom1 = atom(0)
+    atom1.debugLabel = 'atom1'
+    unsubAtom1 = store.sub(atom1, () => {})
+
+    atom2 = atom('initial')
+    atom2.debugLabel = 'atom2'
+    store.sub(atom2, () => {})
+
+    privateAtom = atom(false)
+    privateAtom.debugPrivate = true
+    store.sub(privateAtom, () => {})
+  })
+
+  it('should track history of changes to all atoms in a store', () => {
+    store.set(atom1, 1)
+    store.set(atom1, 2)
+    store.set(atom2, 'updated')
+
+    const history = store.get(historyAtom)
+    expect(history.get(atom1)).toEqual([2, 1, 0])
+    expect(history.get(atom2)).toEqual(['updated', 'initial'])
+  })
+
+  it('should not track changes of atoms that are private', () => {
+    store.set(atom1, 1)
+    store.set(privateAtom, true)
+
+    const history = store.get(historyAtom)
+    expect(history.get(atom1)).toEqual([1, 0])
+    expect(history.has(privateAtom)).toBe(false)
+  })
+
+  it('should track changes across multiple stores', () => {
+    const store2 = createStore()
+    const historyAtom2 = atomWithStoreHistory(3)
+    store2.sub(historyAtom2, () => {})
+    store2.sub(atom1, () => {})
+
+    store.set(atom1, 1)
+    store2.set(atom1, 2)
+
+    const history1 = store.get(historyAtom)
+    const history2 = store2.get(historyAtom2)
+
+    expect(history1.get(atom1)).toEqual([1, 0])
+    expect(history2.get(atom1)).toEqual([2, 0])
+  })
+
+  it('should limit the history to the specified number of entries', () => {
+    store.set(atom1, 1)
+    store.set(atom1, 2)
+    store.set(atom1, 3)
+    store.set(atom1, 4)
+
+    const history = store.get(historyAtom)
+    expect(history.get(atom1)?.length).toBe(3)
+    expect(history.get(atom1)).toEqual([4, 3, 2])
+  })
+
+  it('should reset the history when an atom is reset', () => {
+    store.set(atom1, 1)
+    store.set(atom1, 2)
+    store.set(atom2, 'updated')
+
+    store.set(historyAtom, RESET)
+
+    const history = store.get(historyAtom)
+    expect(history.size).toBe(0)
+  })
+
+  it('should clear the history when an atom is unmounted', () => {
+    store.set(atom1, 1)
+    store.set(atom2, 'updated')
+
+    const history = store.get(historyAtom)
+    expect(history.has(atom1)).toBe(true)
+
+    // unmount atom1
+    unsubAtom1()
+
+    expect(history.has(atom1)).toBe(false)
+    expect(history.has(atom2)).toBe(true)
+  })
+
+  it('should unsubscribe from store hooks when the atom is unmounted', () => {
+    store.set(atom1, 1)
+
+    // Unmount the history atom
+    unsubHistory()
+
+    // Create a new atom after unmounting
+    const atom3 = atom('new')
+    store.sub(atom3, () => {})
+    store.set(atom3, 'changed')
+
+    // History should be empty or not track new changes
+    const history = store.get(historyAtom)
+    expect(history.has(atom3)).toBe(false)
+
+    // Remount to verify it works again
+    unsubHistory = store.sub(historyAtom, () => {})
+    store.set(atom3, 'changed again')
+    expect(store.get(historyAtom).has(atom3)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
`atomWithStoreHistory` creates an atom that watches history of every mounted atom in every store it is mounted in.

## Usage
```ts
import { atomWithStoreHistory } from 'jota-history'

const store = createStore()

const storeHistoryAtom = atomWithStoreHistory(4)
store.sub(storeHistoryAtom, () => {})

const atom1 = atom('first value')
store.sub(atom1, () => {})

store.set(atom1, 'next value')

store.get(storeHistoryAtom) // Map<atom1, ['next value', 'first value']>
```

## Caveats
1. `atomWithStoreHistory` only tracks mounted atoms in the store.
2. `atomWithStoreHistory` only tracks atom changes _after_ it has mounted in the store.
  - Atom initial values and changes prior to mounting are not captured.
  - Atoms mounted before `atomWithStoreHistory` has mounted that have not changed are not captured.
